### PR TITLE
Print styles

### DIFF
--- a/sass/_print.scss
+++ b/sass/_print.scss
@@ -1,0 +1,120 @@
+// We use the print styles from HTML5 Boilerplate as a start,
+// and then additionally hide elements like the header/footer,
+// and remove padding on main page elements.
+
+@media print {
+    *,
+    *:before,
+    *:after {
+        background: transparent !important;
+        color: #000 !important;
+        box-shadow: none !important;
+        text-shadow: none !important;
+    }
+
+    a,
+    a:visited {
+        text-decoration: underline;
+    }
+
+    a[href]:after,
+    abbr[title]:after {
+        content: " (" attr(href) ")";
+        display: inline-block;
+        text-decoration: none;
+        font-style: italic;
+        margin-left: 0.3em;
+    }
+
+    abbr[title]:after {
+        content: " (" attr(title) ")";
+    }
+
+    a[href^="#"]:after,
+    a[href^="javascript:"]:after {
+        content: "";
+    }
+
+    pre,
+    blockquote {
+        border: 1px solid #999;
+        page-break-inside: avoid;
+    }
+
+    thead {
+        display: table-header-group;
+    }
+
+    tr,
+    img {
+        page-break-inside: avoid;
+    }
+
+    img {
+        max-width: 100% !important;
+    }
+
+    p,
+    h2,
+    h3 {
+        orphans: 3;
+        widows: 3;
+    }
+
+    h2,
+    h3 {
+        page-break-after: avoid;
+    }
+
+    @page {
+        margin: 1cm;
+    }
+
+    .ms-header,
+    .site-header,
+    .site-footer,
+    .breadcrumb,
+    .sidebar {
+        display: none !important;
+    }
+
+    .container,
+    .page,
+    .main-content,
+    .secondary-content-column {
+        padding: 0;
+    }
+
+    .container,
+    .page {
+        max-width: none;
+        margin: 0;
+    }
+
+    .main-content-column,
+    .secondary-content-column {
+        float: none;
+    }
+
+    pre {
+        overflow: auto; // remove empty scrollbar from print output
+        border: 1px solid #ccc;
+        font-size: 0.3cm; // quite small, but should avoid most text wrapping
+    }
+
+    // Use a left border, rather than background colour,
+    // to attract attention.
+    .attention-box {
+        padding: 0 1em;
+        margin: 1em 0 1em 1em;
+        border-left: 0.1cm solid $colour_blue;
+
+        &.helpful-hint {
+          border-left-color: $colour_yellow;
+        }
+
+        &.warning {
+          border-left-color: $colour_red;
+        }
+    }
+}

--- a/sass/global.scss
+++ b/sass/global.scss
@@ -706,3 +706,5 @@ table.table td {
     }
     a {color: #eeeeee;}
 }
+
+@import 'print';


### PR DESCRIPTION
Includes all the goodness from the HTML5 Boilerplate print styles (eg: printed hrefs after links, removal of background and text colours) as well as removal of the header, footer, and sidebar, and some print-friendly styling for code snippets and attention boxes.

Fixes #17.

Here’s an example screenshot of it in action in the Alaveteli docs:

![screen shot 2015-10-28 at 16 23 47](https://cloud.githubusercontent.com/assets/739624/10795157/53e22d52-7d90-11e5-8721-71a907decd77.png)

The only bit I'm not 100% confident about is the code block font size. I've reduced it down to 0.3cm in an attempt to stop lines wrapping (because CSS has no obvious way of showing that a line has been soft-wrapped). If people are typing in code from a print-out, they're in dangerous territory anyway, but I'm not sure which is the best way to help them – make the text so small people with poor vision might not be able to read it, or keep it large but run the risk of it being unexpectedly soft-wrapped?

Thoughts @davewhiteland, @dracos?