### PR TITLE
Simpler clearfix for .page-wrapper

### DIFF
--- a/sass/global.scss
+++ b/sass/global.scss
@@ -143,12 +143,11 @@ blockquote {
 /* To avoid floaty footer, make background footer colour */
 .page-wrapper {
     background: $colour_background;
-    float: left;
-    width: 100%;
+    @include clearfix();
 }
 .page-wrapper--white {
-    width: 100%;
     background: #fff;
+    @include clearfix();
 }
 
 /* mySociety header */

--- a/sass/global.scss
+++ b/sass/global.scss
@@ -140,7 +140,6 @@ blockquote {
     font-style: italic;
 }
 
-/* To avoid floaty footer, make background footer colour */
 .page-wrapper {
     background: $colour_background;
     @include clearfix();


### PR DESCRIPTION
Spotted a weird floating issue on the alaveteli documentation pages while I was implementing the [standard mySociety footer for alaveteli.org](https://github.com/mysociety/mysociety-docs-theme/issues/19) – and tracked it down to a `float: left` on `.page-wrapper`.

As far as I could tell, the float was introduced as a way of clearing the page’s floated children, which is uneccessary when we can use `@include clearfix()` instead.

It might be that the float was *really* there for a different reason. @davewhiteland @dracos will probably know best.