### PR TITLE
Inherit config from Sass scope

### DIFF
--- a/sass/_variables.scss
+++ b/sass/_variables.scss
@@ -30,29 +30,29 @@ $medium-screen: 30em;
 $base-spacing-unit: 32px;
 
 
-// These *should always* be overridden in _config.scss
+// These *should always* be overridden
 
 $logo_path: "../../theme/img/fixmystreet-logo.svg" !default;
 $logo_height: 60px !default;
 $logo_width: 320px !default;
 
 
-// These footer settings *can* be overridden in _config.scss
+// These footer settings *can* be overridden
 
-$mysoc-footer-background-color: $colour_black;
-$mysoc-footer-text-color: #acacac;
-$mysoc-footer-site-name-text-color: #fff;
+$mysoc-footer-background-color: $colour_black !default;
+$mysoc-footer-text-color: #acacac !default;
+$mysoc-footer-site-name-text-color: #fff !default;
 
-$mysoc-footer-link-text-color: #fff;
-$mysoc-footer-link-hover-text-color: #fff;
+$mysoc-footer-link-text-color: #fff !default;
+$mysoc-footer-link-hover-text-color: #fff !default;
 
-$mysoc-footer-divider-color: #4b4b4b;
+$mysoc-footer-divider-color: #4b4b4b !default;
 
-$mysoc-footer-donate-background-color: lighten($colour_black, 5%);
-$mysoc-footer-donate-text-color: #fff;
-$mysoc-footer-donate-button-background-color: #E04B4B;
+$mysoc-footer-donate-background-color: lighten($colour_black, 5%) !default;
+$mysoc-footer-donate-text-color: #fff !default;
+$mysoc-footer-donate-button-background-color: #E04B4B !default;
 
-$mysoc-footer-legal-text-color: #9a9a9a;
+$mysoc-footer-legal-text-color: #9a9a9a !default;
 
-$mysoc-footer-image-path: '../../theme/img/mysoc-footer/';
-$mysoc-footer-breakpoint-sm: $large-screen;
+$mysoc-footer-image-path: '../../theme/img/mysoc-footer/' !default;
+$mysoc-footer-breakpoint-sm: $large-screen !default;

--- a/sass/global.scss
+++ b/sass/global.scss
@@ -2,11 +2,12 @@
 @import 'variables';
 @import 'mixins';
 @import 'pygment_trac';
-@import '../../assets/sass/config';
 
 *, *:before, *:after {
-  -moz-box-sizing: border-box; -webkit-box-sizing: border-box; box-sizing: border-box;
- }
+    -moz-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+}
 
 html {
     height: 100%;


### PR DESCRIPTION
Fixes #23.

mysociety-docs-theme no longer attempts to `@import` a config file from the parent project.

If you’re using mysociety-docs-theme, you should make sure that your config (eg: `$logo_path`) is imported into scope *before* global.scss is imported.