### PR TITLE
More attention box colours

### DIFF
--- a/sass/global.scss
+++ b/sass/global.scss
@@ -524,7 +524,16 @@ table.table td {
       background-color: mix(#fff, $colour_yellow, 75%);
     }
 
+    &.success {
+      background-color: mix(#fff, $colour_green, 85%);
+    }
+
     &.warning {
+      background-color: mix(#fff, $colour_orange, 85%);
+    }
+
+    &.error,
+    &.danger {
       background-color: mix(#fff, $colour_red, 85%);
     }
 


### PR DESCRIPTION
We needed a `.success` class for attention-boxes in mapit.mysociety.org so I figured we should just add it to the docs theme so other sites can use it too.

While I was there, I split the existing red `.warning` style, into a red `.error` style and an orange `.warning` style. The warning/error distinction is more consistent with how other libraries like bootstrap do their alerts.

`.danger` also added as an alias for `.error`, for those with bootstrap muscle memory ;-)

![screen shot](https://cloud.githubusercontent.com/assets/739624/22699418/44923fba-ed4f-11e6-8ea5-fc9a65db9fc2.png)
